### PR TITLE
Update board.html to fix currentBoard name trunction

### DIFF
--- a/views/board.html
+++ b/views/board.html
@@ -32,7 +32,7 @@
             crossorigin="anonymous"></script>
     <script>
       $(function() {
-        var currentBoard = window.location.pathname.slice(3,-1);
+        var currentBoard = window.location.pathname.replace(/^\/b\//,"");
         var url = "/api/threads/"+currentBoard;
         $('#boardTitle').text('Welcome to '+window.location.pathname)
         $.ajax({


### PR DESCRIPTION
issue: when creating a new thread in the board.html, the board name was being truncated when form was submitted- usually one character at the end. 
example:  
window.location.pathname = /b/test
after posting, board would equal "tes"

fixed: replaced the 'slice' method being used, with 'replace' instead. It's a bit more clear.